### PR TITLE
Enable high load runs

### DIFF
--- a/SampleUsages/SampleUsages.csproj
+++ b/SampleUsages/SampleUsages.csproj
@@ -64,6 +64,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="TestSamples\AwsQueueLowLoadTests.json" />
     <None Include="TestSamples\AwsQueueMediumLoadTests.json" />
+    <None Include="TestSamples\AzureQueueShortRunTests.json" />
+    <None Include="TestSamples\AzureQueueHighLoadTests.json" />
     <None Include="TestSamples\AzureQueueMediumLoadTests.json" />
     <None Include="TestSamples\AzureQueueLowLoadTests.json" />
     <Compile Include="TestScenario.cs" />

--- a/SampleUsages/TestSamples/AzureQueueHighLoadTests.json
+++ b/SampleUsages/TestSamples/AzureQueueHighLoadTests.json
@@ -1,0 +1,28 @@
+﻿[
+  {
+    "functionName": "Queue-NodeJs-CPUIntensive",
+    "platform": "Azure",
+    "inputPath": "..\\queueitems-static-64.config",
+    "triggerType": "Queue",
+    "loadProfile": "Linear",
+    "inputObject": "samples-node-js-cpu-perf-test",
+    "outputObject": "samples-node-js-cpu-perf-test-output",
+    "eps": 1000,
+    "repeat": true,
+    "durationInMinutes": 20,
+    "warmUpTimeInMinutes": 5
+  },
+  {
+    "functionName": "Queue-CSharp-CPUIntensive",
+    "platform": "Azure",
+    "inputPath": "..\\queueitems-static-64.config",
+    "triggerType": "Queue",
+    "loadProfile": "Linear",
+    "inputObject": "samples-csharp-cpu-perf-test",
+    "outputObject": "samples-csharp-cpu-perf-test-output",
+    "eps": 1000,
+    "repeat": true,
+    "durationInMinutes": 20,
+    "warmUpTimeInMinutes": 5
+  }
+]

--- a/SampleUsages/TestSamples/AzureQueueShortRunTests.json
+++ b/SampleUsages/TestSamples/AzureQueueShortRunTests.json
@@ -1,0 +1,28 @@
+﻿[
+  {
+    "functionName": "Queue-NodeJs-CPUIntensive",
+    "platform": "Azure",
+    "inputPath": "..\\queueitems-static-64.config",
+    "triggerType": "Queue",
+    "loadProfile": "Linear",
+    "inputObject": "samples-node-js-cpu-perf-test",
+    "outputObject": "samples-node-js-cpu-perf-test-output",
+    "eps": 10,
+    "repeat": true,
+    "durationInMinutes": 1,
+    "warmUpTimeInMinutes": 0
+  },
+  {
+    "functionName": "Queue-CSharp-CPUIntensive",
+    "platform": "Azure",
+    "inputPath": "..\\queueitems-static-64.config",
+    "triggerType": "Queue",
+    "loadProfile": "Linear",
+    "inputObject": "samples-csharp-cpu-perf-test",
+    "outputObject": "samples-csharp-cpu-perf-test-output",
+    "eps": 10,
+    "repeat": true,
+    "durationInMinutes": 1,
+    "warmUpTimeInMinutes": 0
+  }
+]

--- a/ServerlessBenchmark/LoadProfiles/TriggerTestLoadProfile.cs
+++ b/ServerlessBenchmark/LoadProfiles/TriggerTestLoadProfile.cs
@@ -40,12 +40,12 @@ namespace ServerlessBenchmark.LoadProfiles
                 await loadAction;
             };
             _calculateRateTimer = new Timer(callback, null, 0, 1000 * 1);
-            var isLoadFinishedTask = Task.Run(() =>
+            var isLoadFinishedTask = Task.Run(async () =>
             {
                 while (!IsFinished())
                 {
                     //keep cycling
-                    Task.Delay(TimeSpan.FromSeconds(1));
+                    await Task.Delay(TimeSpan.FromSeconds(1));
                 }
             });
 

--- a/ServerlessBenchmark/ServerlessBenchmark.csproj
+++ b/ServerlessBenchmark/ServerlessBenchmark.csproj
@@ -98,6 +98,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/ServerlessBenchmark/packages.config
+++ b/ServerlessBenchmark/packages.config
@@ -13,6 +13,7 @@
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="OxyPlot.Core" version="1.0.0-unstable2100" targetFramework="net45" />
   <package id="System.Net.Http" version="2.0.20710.0" targetFramework="net45" />


### PR DESCRIPTION
The tool can now do high load runs against Azure Queues. The major fixes were making the client resilient to occasional failure and constraining concurrency.