### PR TITLE
Fix Issue#33. Enable different storage connection strings on a per sc…

### DIFF
--- a/SampleUsages/TestScenario.cs
+++ b/SampleUsages/TestScenario.cs
@@ -24,6 +24,7 @@ namespace SampleUsages
         public bool Repeat { get; set; }
         public int DurationInMinutes { get; set; }
         public int WarmUpTimeInMinutes { get; set; }
+        public string AzureStorageConnectionString { get; set; }
         private ILogger _logger { get; set; }
 
         internal void RunScenario(ILogger logger)
@@ -66,7 +67,7 @@ namespace SampleUsages
             {
                 AssertInput("InputPath", "FunctionName", "InputObject", "OutputObject");
                 var blobs = Directory.GetFiles(this.InputPath);
-                test = new AzureBlobTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, blobs, this.InputObject, this.OutputObject);
+                test = new AzureBlobTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, blobs, this.InputObject, this.OutputObject, this.AzureStorageConnectionString);
                 inputCount = blobs.Count();
             }
             else if (scenarioType.Compare(Platform.Azure, TriggerType.Http))
@@ -80,7 +81,7 @@ namespace SampleUsages
             {
                 AssertInput("FunctionName", "InputObject", "OutputObject");
                 var queueMessages = File.ReadAllLines(this.InputPath);
-                test = new AzureQueueTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, queueMessages, this.InputObject, this.OutputObject);
+                test = new AzureQueueTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, queueMessages, this.InputObject, this.OutputObject, this.AzureStorageConnectionString);
                 inputCount = queueMessages.Count();
             }
             else

--- a/SampleUsages/TestScenario.cs
+++ b/SampleUsages/TestScenario.cs
@@ -24,7 +24,7 @@ namespace SampleUsages
         public bool Repeat { get; set; }
         public int DurationInMinutes { get; set; }
         public int WarmUpTimeInMinutes { get; set; }
-        public string AzureStorageConnectionString { get; set; }
+        public string AzureStorageConnectionStringConfigName { get; set; }
         private ILogger _logger { get; set; }
 
         internal void RunScenario(ILogger logger)
@@ -67,7 +67,7 @@ namespace SampleUsages
             {
                 AssertInput("InputPath", "FunctionName", "InputObject", "OutputObject");
                 var blobs = Directory.GetFiles(this.InputPath);
-                test = new AzureBlobTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, blobs, this.InputObject, this.OutputObject, this.AzureStorageConnectionString);
+                test = new AzureBlobTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, blobs, this.InputObject, this.OutputObject, this.AzureStorageConnectionStringConfigName);
                 inputCount = blobs.Count();
             }
             else if (scenarioType.Compare(Platform.Azure, TriggerType.Http))
@@ -81,7 +81,7 @@ namespace SampleUsages
             {
                 AssertInput("FunctionName", "InputObject", "OutputObject");
                 var queueMessages = File.ReadAllLines(this.InputPath);
-                test = new AzureQueueTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, queueMessages, this.InputObject, this.OutputObject, this.AzureStorageConnectionString);
+                test = new AzureQueueTriggerTest(this.FunctionName, this.Eps, this.WarmUpTimeInMinutes, queueMessages, this.InputObject, this.OutputObject, this.AzureStorageConnectionStringConfigName);
                 inputCount = queueMessages.Count();
             }
             else

--- a/ServerlessBenchmark/ServerlessPlatformControllers/Azure/AzureController.cs
+++ b/ServerlessBenchmark/ServerlessPlatformControllers/Azure/AzureController.cs
@@ -33,9 +33,9 @@ namespace ServerlessBenchmark.ServerlessPlatformControllers.Azure
             get { return storageAccount.CreateCloudBlobClient(); }
         }
 
-        public AzureController(string storageAccountConnectionString = null)
+        public AzureController(string storageAccountConnectionStringConfigName = null)
         {
-            var connectionString = storageAccountConnectionString ?? ConfigurationManager.AppSettings["AzureStorageConnectionString"];
+            var connectionString = ConfigurationManager.AppSettings[storageAccountConnectionStringConfigName] ?? ConfigurationManager.AppSettings["AzureStorageConnectionString"];
 
             if (!string.IsNullOrEmpty(connectionString))
             {

--- a/ServerlessBenchmark/ServerlessPlatformControllers/Azure/AzureController.cs
+++ b/ServerlessBenchmark/ServerlessPlatformControllers/Azure/AzureController.cs
@@ -33,9 +33,9 @@ namespace ServerlessBenchmark.ServerlessPlatformControllers.Azure
             get { return storageAccount.CreateCloudBlobClient(); }
         }
 
-        public AzureController()
+        public AzureController(string storageAccountConnectionString = null)
         {
-            var connectionString = ConfigurationManager.AppSettings["AzureStorageConnectionString"];
+            var connectionString = storageAccountConnectionString ?? ConfigurationManager.AppSettings["AzureStorageConnectionString"];
 
             if (!string.IsNullOrEmpty(connectionString))
             {

--- a/ServerlessBenchmark/TriggerTests/Azure/AzureBlobTriggerTest.cs
+++ b/ServerlessBenchmark/TriggerTests/Azure/AzureBlobTriggerTest.cs
@@ -12,12 +12,12 @@ namespace ServerlessBenchmark.TriggerTests.Azure
 {
     public class AzureBlobTriggerTest:BlobTriggerTest
     {
-        private string _azureStorageConnectionString;
+        private string _azureStorageConnectionStringConfigName;
 
         public AzureBlobTriggerTest(string functionName, int eps, int warmUpTimeInMinutes, IEnumerable<string> blobs, string inputContainer,
-            string outputContainer, string azureStorageAccountConnectionString = null) : base(functionName, eps, warmUpTimeInMinutes, blobs.ToArray(), inputContainer, outputContainer)
+            string outputContainer, string azureStorageConnectionStringConfigName = null) : base(functionName, eps, warmUpTimeInMinutes, blobs.ToArray(), inputContainer, outputContainer)
         {
-            _azureStorageConnectionString = azureStorageAccountConnectionString;
+            _azureStorageConnectionStringConfigName = azureStorageConnectionStringConfigName;
         }
 
         protected override bool Setup()
@@ -34,7 +34,7 @@ namespace ServerlessBenchmark.TriggerTests.Azure
         {
             get
             {
-                return new AzureController(_azureStorageConnectionString)
+                return new AzureController(_azureStorageConnectionStringConfigName)
                 {
                     Logger = this.Logger
                 };

--- a/ServerlessBenchmark/TriggerTests/Azure/AzureBlobTriggerTest.cs
+++ b/ServerlessBenchmark/TriggerTests/Azure/AzureBlobTriggerTest.cs
@@ -12,15 +12,12 @@ namespace ServerlessBenchmark.TriggerTests.Azure
 {
     public class AzureBlobTriggerTest:BlobTriggerTest
     {
-        public AzureBlobTriggerTest(string functionName, int eps, int warmUpTimeInMinutes, IEnumerable<string> blobs, string inputContainer,
-            string outputContainer) : base(functionName, eps, warmUpTimeInMinutes, blobs.ToArray(), inputContainer, outputContainer)
-        {
-            
-        }
+        private string _azureStorageConnectionString;
 
-        public AzureBlobTriggerTest(string functionName, IEnumerable<string> blobs)
+        public AzureBlobTriggerTest(string functionName, int eps, int warmUpTimeInMinutes, IEnumerable<string> blobs, string inputContainer,
+            string outputContainer, string azureStorageAccountConnectionString = null) : base(functionName, eps, warmUpTimeInMinutes, blobs.ToArray(), inputContainer, outputContainer)
         {
-            //todo find the input and output container given the container name
+            _azureStorageConnectionString = azureStorageAccountConnectionString;
         }
 
         protected override bool Setup()
@@ -37,7 +34,7 @@ namespace ServerlessBenchmark.TriggerTests.Azure
         {
             get
             {
-                return new AzureController
+                return new AzureController(_azureStorageConnectionString)
                 {
                     Logger = this.Logger
                 };

--- a/ServerlessBenchmark/TriggerTests/Azure/AzureQueueTriggerTest.cs
+++ b/ServerlessBenchmark/TriggerTests/Azure/AzureQueueTriggerTest.cs
@@ -8,15 +8,19 @@ namespace ServerlessBenchmark.TriggerTests.Azure
 {
     public class AzureQueueTriggerTest:QueueTriggerTest
     {
-        public AzureQueueTriggerTest(string functionName, int eps, int warmUpTimeInMinutes, string[] messages, string sourceQueue, string targetQueue) : base(functionName, eps, warmUpTimeInMinutes, messages, sourceQueue, targetQueue)
+        private string _azureStorageConnectionString;
+
+        public AzureQueueTriggerTest(string functionName, int eps, int warmUpTimeInMinutes, string[] messages, 
+            string sourceQueue, string targetQueue, string azureStorageConnectionString = null) : base(functionName, eps, warmUpTimeInMinutes, messages, sourceQueue, targetQueue)
         {
+            _azureStorageConnectionString = azureStorageConnectionString;
         }
 
         protected override ICloudPlatformController CloudPlatformController
         {
             get
             {
-                return new AzureController
+                return new AzureController(_azureStorageConnectionString)
                 {
                     Logger = this.Logger
                 };

--- a/ServerlessBenchmark/TriggerTests/Azure/AzureQueueTriggerTest.cs
+++ b/ServerlessBenchmark/TriggerTests/Azure/AzureQueueTriggerTest.cs
@@ -8,19 +8,19 @@ namespace ServerlessBenchmark.TriggerTests.Azure
 {
     public class AzureQueueTriggerTest:QueueTriggerTest
     {
-        private string _azureStorageConnectionString;
+        private string _azureStorageConnectionStringConfigName;
 
         public AzureQueueTriggerTest(string functionName, int eps, int warmUpTimeInMinutes, string[] messages, 
-            string sourceQueue, string targetQueue, string azureStorageConnectionString = null) : base(functionName, eps, warmUpTimeInMinutes, messages, sourceQueue, targetQueue)
+            string sourceQueue, string targetQueue, string azureStorageConnectionStringConfigName = null) : base(functionName, eps, warmUpTimeInMinutes, messages, sourceQueue, targetQueue)
         {
-            _azureStorageConnectionString = azureStorageConnectionString;
+            _azureStorageConnectionStringConfigName = azureStorageConnectionStringConfigName;
         }
 
         protected override ICloudPlatformController CloudPlatformController
         {
             get
             {
-                return new AzureController(_azureStorageConnectionString)
+                return new AzureController(_azureStorageConnectionStringConfigName)
                 {
                     Logger = this.Logger
                 };


### PR DESCRIPTION
…enario basis.

Problem: ServerlessBenchmark(SB) assumes that each scenario uses the same azure storage connection string written in secrets.config file. During a queue scenario run, SB will try to clean up the source and destination queues but fail with a 404. #33 

Solution:Enable storage connection string to be added as a scenario property. Propagate the connection string to the platform controller.  