### PR TITLE
Fix Function Log Connection String Regression

### DIFF
--- a/ServerlessBenchmark/PerfResultProviders/AzureGenericPerformanceResultsProvider.cs
+++ b/ServerlessBenchmark/PerfResultProviders/AzureGenericPerformanceResultsProvider.cs
@@ -8,6 +8,9 @@ namespace ServerlessBenchmark.PerfResultProviders
 {
     public class AzureGenericPerformanceResultsProvider : AzurePerformanceResultProviderBase
     {
+        public AzureGenericPerformanceResultsProvider(string storageAccountConnectionStringConfigName = null) :
+            base(storageAccountConnectionStringConfigName) { }
+
         protected override Dictionary<string, string> ObtainAdditionalPerfMetrics(PerfTestResult genericPerfTestResult, string functionName, DateTime testStartTime,
             DateTime testEndTime)
         {

--- a/ServerlessBenchmark/PerfResultProviders/AzurePerformanceResultProviderBase.cs
+++ b/ServerlessBenchmark/PerfResultProviders/AzurePerformanceResultProviderBase.cs
@@ -13,6 +13,12 @@ namespace ServerlessBenchmark.PerfResultProviders
     public abstract class AzurePerformanceResultProviderBase:PerfResultProvider
     {
         private List<FunctionLogs.AzureFunctionLogs> _logs;
+        private string _storageAccountConnectionStringConfigName;
+
+        public AzurePerformanceResultProviderBase(string storageAccountConnectionStringConfigName = null)
+        {
+            _storageAccountConnectionStringConfigName = storageAccountConnectionStringConfigName;
+        }
         
         [PerfMetric(PerfMetrics.AverageExecutionTime)]
         protected TimeSpan? CalculateAverageExecutionTime(string functionName, DateTime testStartTime, DateTime testEndTime, int expectedExecutionCount)
@@ -257,7 +263,7 @@ namespace ServerlessBenchmark.PerfResultProviders
         {
             if (_logs == null)
             {
-                _logs = PerfResultProviders.FunctionLogs.GetAzureFunctionLogs(functionName, testStartTime, expectedExecutions);                
+                _logs = PerfResultProviders.FunctionLogs.GetAzureFunctionLogs(functionName, testStartTime, expectedExecutions, storageAccountConnectionStringConfigName: _storageAccountConnectionStringConfigName);                
             }
             return _logs;
         }

--- a/ServerlessBenchmark/PerfResultProviders/FunctionLogs.cs
+++ b/ServerlessBenchmark/PerfResultProviders/FunctionLogs.cs
@@ -45,14 +45,16 @@ namespace ServerlessBenchmark.PerfResultProviders
             }
         }
 
-        public static List<AzureFunctionLogs> GetAzureFunctionLogs(string functionName, DateTime? startTime, int expectedExecutionCount = 0, int waitForAllLogsTimeoutInMinutes = 2, bool includeIncomplete = false)
+        public static List<AzureFunctionLogs> GetAzureFunctionLogs(string functionName, DateTime? startTime, 
+            int expectedExecutionCount = 0, int waitForAllLogsTimeoutInMinutes = 2, bool includeIncomplete = false,
+            string storageAccountConnectionStringConfigName = null)
         {
-            return GetAzureFunctionLogsInternal(functionName, startTime, expectedExecutionCount, waitForAllLogsTimeoutInMinutes, includeIncomplete);
+            return GetAzureFunctionLogsInternal(functionName, startTime, expectedExecutionCount, waitForAllLogsTimeoutInMinutes, includeIncomplete, storageAccountConnectionStringConfigName: storageAccountConnectionStringConfigName);
         }
 
-        public static List<AzureFunctionLogs> GetAzureFunctionLogs(string functionName)
+        public static List<AzureFunctionLogs> GetAzureFunctionLogs(string functionName, string storageAccountConnectionStringConfigName = null)
         {
-            return GetAzureFunctionLogs(functionName, null);
+            return GetAzureFunctionLogs(functionName, null, storageAccountConnectionStringConfigName: storageAccountConnectionStringConfigName);
         }
 
         public static bool RemoveAllCLoudWatchLogs(string functionName)
@@ -84,10 +86,12 @@ namespace ServerlessBenchmark.PerfResultProviders
             return tablePurged;
         }
 
-        private static List<AzureFunctionLogs> GetAzureFunctionLogsInternal(string functionName, DateTime? startTime, int expectedExecutionCount, int waitForAllLogsTimeoutInMinutes, bool includeIncomplete)
+        private static List<AzureFunctionLogs> GetAzureFunctionLogsInternal(string functionName, DateTime? startTime, 
+            int expectedExecutionCount, int waitForAllLogsTimeoutInMinutes, bool includeIncomplete,
+            string storageAccountConnectionStringConfigName = null)
         {
             _logger.LogInfo("Getting Azure Function logs from Azure Storage Tables..");
-            var connectionString = ConfigurationManager.AppSettings["AzureStorageConnectionString"];
+            var connectionString = ConfigurationManager.AppSettings[storageAccountConnectionStringConfigName] ?? ConfigurationManager.AppSettings["AzureStorageConnectionString"];
             var _azurefunctionLogs = new List<AzureFunctionLogs>();
 
             if (!string.IsNullOrEmpty(connectionString))

--- a/ServerlessBenchmark/TriggerTests/Azure/AzureBlobTriggerTest.cs
+++ b/ServerlessBenchmark/TriggerTests/Azure/AzureBlobTriggerTest.cs
@@ -43,7 +43,7 @@ namespace ServerlessBenchmark.TriggerTests.Azure
 
         protected override PerfResultProvider PerfmormanceResultProvider
         {
-            get { return new AzureGenericPerformanceResultsProvider { DatabaseTest = this.TestWithResults }; }
+            get { return new AzureGenericPerformanceResultsProvider(_azureStorageConnectionStringConfigName) { DatabaseTest = this.TestWithResults }; }
         }
 
         private bool RemoveAzureFunctionLogs()

--- a/ServerlessBenchmark/TriggerTests/Azure/AzureQueueTriggerTest.cs
+++ b/ServerlessBenchmark/TriggerTests/Azure/AzureQueueTriggerTest.cs
@@ -29,7 +29,7 @@ namespace ServerlessBenchmark.TriggerTests.Azure
 
         protected override PerfResultProvider PerfmormanceResultProvider
         {
-            get { return new AzureGenericPerformanceResultsProvider { DatabaseTest = this.TestWithResults }; }
+            get { return new AzureGenericPerformanceResultsProvider(_azureStorageConnectionStringConfigName) { DatabaseTest = this.TestWithResults}; }
         }
 
         protected override bool Setup()


### PR DESCRIPTION
Before: When fetching function logs from storage account, the logic would assume the default storage connection string name in the secrets.config file. eg., "AzureStorageConnectionString"
Now: Given a connection string name, function logs will get the correct connection string from secrets.config file. 